### PR TITLE
Allow for `None` as selection via Optional String

### DIFF
--- a/Sources/SymbolPicker/Resources/en.lproj/Localizable.strings
+++ b/Sources/SymbolPicker/Resources/en.lproj/Localizable.strings
@@ -2,3 +2,4 @@
 "cancel" = "Cancel";
 "sf_symbol_picker" = "Select a symbol";
 "done" = "Done";
+"none" = "None";

--- a/Sources/SymbolPicker/SymbolPicker.swift
+++ b/Sources/SymbolPicker/SymbolPicker.swift
@@ -178,7 +178,7 @@ public struct SymbolPicker: View {
                     } label: {
                         if symbol == nil {
                             Text("None")
-                                .font(.system(size: Self.symbolSize))
+                                .font(.headline)
 #if os(tvOS)
                                 .frame(minWidth: Self.gridDimension, minHeight: Self.gridDimension)
 #else
@@ -189,7 +189,7 @@ public struct SymbolPicker: View {
                                 .foregroundColor(.white)
                         } else {
                             Text("None")
-                                .font(.system(size: Self.symbolSize))
+                                .font(.headline)
                                 .frame(maxWidth: .infinity, minHeight: Self.gridDimension)
                                 .background(Self.unselectedItemBackgroundColor)
                                 .cornerRadius(Self.symbolCornerRadius)

--- a/Sources/SymbolPicker/SymbolPicker.swift
+++ b/Sources/SymbolPicker/SymbolPicker.swift
@@ -93,7 +93,9 @@ public struct SymbolPicker: View {
             return symbol.wrappedValue
         }, set: { newValue in
             /// As the `canBeNone` is set to `false`, this can not be `nil`
-            symbol.wrappedValue = newValue!
+            if let newValue {
+                symbol.wrappedValue = newValue
+            }
         })
         canBeNone = false
     }
@@ -177,7 +179,7 @@ public struct SymbolPicker: View {
                         presentationMode.wrappedValue.dismiss()
                     } label: {
                         if symbol == nil {
-                            Text("None")
+                            Text(LocalizedString("none"))
                                 .font(.headline)
 #if os(tvOS)
                                 .frame(minWidth: Self.gridDimension, minHeight: Self.gridDimension)
@@ -188,7 +190,7 @@ public struct SymbolPicker: View {
                                 .cornerRadius(Self.symbolCornerRadius)
                                 .foregroundColor(.white)
                         } else {
-                            Text("None")
+                            Text(LocalizedString("none"))
                                 .font(.headline)
                                 .frame(maxWidth: .infinity, minHeight: Self.gridDimension)
                                 .background(Self.unselectedItemBackgroundColor)


### PR DESCRIPTION
- Basically #3, but with an `nil` instead of `""`.
- Should not break support, as it only adds a new `init` to the public interface.
- I am not into localisation, therefore I this would need to be addressed after merge.

Thanks for the great library, I hope I can help with this quick feature addition.

Greetings from Munich,
Lucas